### PR TITLE
Fix for when body of pull request is null

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7105,7 +7105,7 @@ const getPullRequestBody = async ({
         pull_number: pullNumber,
     });
 
-    return data.body;
+    return data.body || "";
 };
 
 /**
@@ -7376,20 +7376,12 @@ const run = async () => {
     const octokit = getOctokit(token);
 
     const sources = core.getInput('sources', {required: true});
-    const ignoreActionLabel = core.getInput('ignoreActionLabel');
 
     const repo = context.payload.repository.name;
     const owner = context.payload.repository.full_name.split('/')[0];
     const pullNumber = context.payload.pull_request.number;
-    const labels = context.payload.pull_request.labels.map((label) => label.name);
 
     try {
-        // Ignore the action if -output label (or custom name) exists
-        if (labels.includes(ignoreActionLabel)) {
-            core.info(`Ignore the action due to label ${ignoreActionLabel}`);
-            process.exit(0);
-        }
-
         const pullRequest = {
             octokit,
             owner,

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ const getPullRequestBody = async ({
         pull_number: pullNumber,
     });
 
-    return data.body;
+    return data.body || "";
 };
 
 /**


### PR DESCRIPTION
The body of a PR can is a `null` literal when the PR's body is completely blank.

This causes a `.trim()` invocation to fail later on by null reference.

