### PR TITLE
Unique names for each output job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [2.0.0] - Unreleased
 
-Added unique name for each output entity
+## Added
+- Unique name for each output entity
+- Option to position content on top of the pull-request description
 
 ## [1.0.1] - 23.08.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [2.0.0] - Unreleased
+
+Added unique name for each output entity
+
 ## [1.0.1] - 23.08.2022
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ Required. GitHub token
 String with folders containing md files separated by commas (Supports glob pattern)
 Example : 'projects/app/stats/, projects/embed/errors/'
 
+### `name`
+
+`string`
+
+Required. Name to identify the output entity
+
+### `top`
+
+`string - boolean like`
+
+Optional. set to `true` to position content at the top of the pull requests description
+
+
 ## Usage Example
 
 ````yaml

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   sources:
     description: 'String with folders containing md files separated by commas (Supports glob pattern)'
     required: true
+  name:
+    description: 'Unique name for the specific output job'
+    required: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   name:
     description: 'Unique name for the specific output job'
     required: true
+  top:
+    required: false
+    description: 'indicates if output should be on top of the description'
+    default: 'false'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -7169,7 +7169,7 @@ const combineBody = (data) => {
     } else if (!outputText) {
         return previousBody;
     } else if (data.top) {
-        return output.concat(previousBody);
+        return output.concat(`\n${previousBody}`);
     } else {
         return previousBody.trim().concat(output);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -7087,7 +7087,14 @@ exports.HttpClient = HttpClient;
 /***/ 543:
 /***/ (function(module) {
 
-const outputRegex = /<!-- output start -->(.|\r\n|\n)*<!-- output end -->/i;
+/**
+ *
+ * @param {string} name
+ * @returns {RegExp}
+ */
+const getOutputRegex = (name) => {
+    return new RegExp(`<!-- output start - ${name} -->(.|\\r\\n|\\n)*<!-- output end - ${name} -->`, 'i');
+};
 
 /**
  * Returns the body of the given pull request
@@ -7132,30 +7139,33 @@ const updatePullRequestBody = async ({
  * Indicates if a text
  * contains the output block
  *
+ * @param {string} name
  * @param {string} commentBody
- * @returns {string}
+ * @returns {boolean}
  */
-const hasOutput = (commentBody) => {
-    return outputRegex.test(commentBody);
+const hasOutput = (name, commentBody) => {
+    return getOutputRegex(name).test(commentBody);
 };
 
 /**
  * Cleans the previous output and attaches the new information
+ * @param {string} name
  * @param {string} previousBody - comment in the pull request
  * @param {string} [outputText] - without content will clean the previous output
  * @returns {string}
  */
-const combineBody = (previousBody, outputText) => {
-    if (hasOutput(previousBody)) {
+const combineBody = (name, previousBody, outputText) => {
+    if (hasOutput(name, previousBody)) {
         return previousBody.replace(
-            outputRegex,
-            outputText ? `\n<!-- output start -->\n${outputText}\n<!-- output end -->` : '',
+            getOutputRegex(name),
+            outputText ? `\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->` : '',
         ).trim();
     } else {
+        console.log('here');
         return outputText
             ? previousBody
                 .trim()
-                .concat(`\n<!-- output start -->\n${outputText}\n<!-- output end -->`)
+                .concat(`\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->`)
             : previousBody;
     }
 };
@@ -7376,6 +7386,7 @@ const run = async () => {
     const octokit = getOctokit(token);
 
     const sources = core.getInput('sources', {required: true});
+    const name = core.getInput('name', {required: true});
 
     const repo = context.payload.repository.name;
     const owner = context.payload.repository.full_name.split('/')[0];
@@ -7408,20 +7419,20 @@ const run = async () => {
         core.debug({pullRequestBody});
 
         if (outputContent.length) {
-            const body = combineBody(pullRequestBody, outputContent.join('\n'));
+            const body = combineBody(name, pullRequestBody, outputContent.join('\n'));
             core.info('Adding output to PR comment');
             core.debug({body});
 
-            updatePullRequestBody({
+            await updatePullRequestBody({
                 ...pullRequest,
                 body,
             });
         } else if (hasOutput(pullRequestBody)) {
-            const body = combineBody(pullRequestBody);
+            const body = combineBody(name, pullRequestBody);
             core.info('Cleaning output from PR comment');
             core.debug({body});
 
-            updatePullRequestBody({
+            await updatePullRequestBody({
                 ...pullRequest,
                 body,
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "output",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Outputs markdown content to pull requests",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const run = async () => {
 
     const sources = core.getInput('sources', {required: true});
     const name = core.getInput('name', {required: true});
+    const top = core.getInput('top', {required: false}) === 'true';
 
     const repo = context.payload.repository.name;
     const owner = context.payload.repository.full_name.split('/')[0];
@@ -58,7 +59,13 @@ const run = async () => {
         core.debug({pullRequestBody});
 
         if (outputContent.length) {
-            const body = combineBody(name, pullRequestBody, outputContent.join('\n'));
+            const body = combineBody({
+                name,
+                top,
+                previousBody: pullRequestBody,
+                outputText: outputContent.join('\n'),
+            });
+
             core.info('Adding output to PR comment');
             core.debug({body});
 
@@ -67,7 +74,11 @@ const run = async () => {
                 body,
             });
         } else if (hasOutput(pullRequestBody)) {
-            const body = combineBody(name, pullRequestBody);
+            const body = combineBody({
+                name,
+                previousBody: pullRequestBody,
+            });
+
             core.info('Cleaning output from PR comment');
             core.debug({body});
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const run = async () => {
     const octokit = getOctokit(token);
 
     const sources = core.getInput('sources', {required: true});
+    const name = core.getInput('name', {required: true});
 
     const repo = context.payload.repository.name;
     const owner = context.payload.repository.full_name.split('/')[0];
@@ -57,20 +58,20 @@ const run = async () => {
         core.debug({pullRequestBody});
 
         if (outputContent.length) {
-            const body = combineBody(pullRequestBody, outputContent.join('\n'));
+            const body = combineBody(name, pullRequestBody, outputContent.join('\n'));
             core.info('Adding output to PR comment');
             core.debug({body});
 
-            updatePullRequestBody({
+            await updatePullRequestBody({
                 ...pullRequest,
                 body,
             });
         } else if (hasOutput(pullRequestBody)) {
-            const body = combineBody(pullRequestBody);
+            const body = combineBody(name, pullRequestBody);
             core.info('Cleaning output from PR comment');
             core.debug({body});
 
-            updatePullRequestBody({
+            await updatePullRequestBody({
                 ...pullRequest,
                 body,
             });

--- a/src/test/utils.test.js
+++ b/src/test/utils.test.js
@@ -2,17 +2,29 @@ const {combineBody} = require('../utils');
 
 describe('CombineBody', () => {
     it('returns the the combined text', () => {
-        const res = combineBody('bar', 'foo', 'bar');
+        const res = combineBody({
+            name: 'bar',
+            previousBody: 'foo',
+            outputText: 'bar',
+        });
         expect(JSON.stringify(res)).toBe(JSON.stringify('foo\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->'));
     });
 
     it('replaces the comment with a new one.', () => {
-        const res = combineBody('bar', 'bar\n\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->', 'baz');
+        const res = combineBody({
+            name: 'bar',
+            previousBody: 'bar\n\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->',
+            outputText: 'baz',
+        });
         expect(JSON.stringify(res)).toBe(JSON.stringify('bar\n\n\n<!-- output start - bar -->\nbaz\n<!-- output end - bar -->'));
     });
 
     it('replaces the comment with a new one while having content after', () => {
-        const res = combineBody('bar', 'bar\n\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->\n\nzap', 'baz');
+        const res = combineBody({
+            name: 'bar',
+            previousBody: 'bar\n\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->\n\nzap',
+            outputText: 'baz',
+        });
         expect(JSON.stringify(res)).toBe(JSON.stringify('bar\n\n\n<!-- output start - bar -->\nbaz\n<!-- output end - bar -->\n\nzap'));
     });
 });

--- a/src/test/utils.test.js
+++ b/src/test/utils.test.js
@@ -2,17 +2,17 @@ const {combineBody} = require('../utils');
 
 describe('CombineBody', () => {
     it('returns the the combined text', () => {
-        const res = combineBody('foo', 'bar');
-        expect(JSON.stringify(res)).toBe(JSON.stringify('foo\n<!-- output start -->\nbar\n<!-- output end -->'));
+        const res = combineBody('bar', 'foo', 'bar');
+        expect(JSON.stringify(res)).toBe(JSON.stringify('foo\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->'));
     });
 
     it('replaces the comment with a new one.', () => {
-        const res = combineBody('bar\n\n<!-- output start -->\nbar\n<!-- output end -->', 'baz');
-        expect(JSON.stringify(res)).toBe(JSON.stringify('bar\n\n<!-- output start -->\nbaz\n<!-- output end -->'));
+        const res = combineBody('bar', 'bar\n\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->', 'baz');
+        expect(JSON.stringify(res)).toBe(JSON.stringify('bar\n\n\n<!-- output start - bar -->\nbaz\n<!-- output end - bar -->'));
     });
 
     it('replaces the comment with a new one while having content after', () => {
-        const res = combineBody('bar\n\n<!-- output start -->\nbar\n<!-- output end -->\n\nzap', 'baz');
-        expect(JSON.stringify(res)).toBe(JSON.stringify('bar\n\n<!-- output start -->\nbaz\n<!-- output end -->\n\nzap'));
+        const res = combineBody('bar', 'bar\n\n<!-- output start - bar -->\nbar\n<!-- output end - bar -->\n\nzap', 'baz');
+        expect(JSON.stringify(res)).toBe(JSON.stringify('bar\n\n\n<!-- output start - bar -->\nbaz\n<!-- output end - bar -->\n\nzap'));
     });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,24 +60,29 @@ const hasOutput = (name, commentBody) => {
 
 /**
  * Cleans the previous output and attaches the new information
- * @param {string} name
- * @param {string} previousBody - comment in the pull request
- * @param {string} [outputText] - without content will clean the previous output
- * @returns {string}
+ * @param {CombineBodyData} data
+ * @return {string}
  */
-const combineBody = (name, previousBody, outputText) => {
+const combineBody = (data) => {
+    const {
+        previousBody,
+        outputText,
+        name,
+    } = data;
+
+    const output = `\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->`;
+
     if (hasOutput(name, previousBody)) {
         return previousBody.replace(
             getOutputRegex(name),
-            outputText ? `\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->` : '',
+            outputText ? output : '',
         ).trim();
+    } else if (!outputText) {
+        return previousBody;
+    } else if (data.top) {
+        return output.concat(previousBody);
     } else {
-        console.log('here');
-        return outputText
-            ? previousBody
-                .trim()
-                .concat(`\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->`)
-            : previousBody;
+        return previousBody.trim().concat(output);
     }
 };
 
@@ -100,3 +105,11 @@ module.exports = {
   * @typedef {Object} UpdatePullRequest
   * @param {string} body
   */
+
+/**
+ * @typedef {Object} CombineBodyData
+ * @prop {string} name - name of the output entity
+ * @prop {string} previousBody - comment in the pull request
+ * @prop {boolean} [top]
+ * @prop {string} [outputText] - without content will clean the previous output
+ */

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,11 @@
-const outputRegex = /<!-- output start -->(.|\r\n|\n)*<!-- output end -->/i;
+/**
+ *
+ * @param {string} name
+ * @returns {RegExp}
+ */
+const getOutputRegex = (name) => {
+    return new RegExp(`<!-- output start - ${name} -->(.|\\r\\n|\\n)*<!-- output end - ${name} -->`, 'i');
+};
 
 /**
  * Returns the body of the given pull request
@@ -43,30 +50,33 @@ const updatePullRequestBody = async ({
  * Indicates if a text
  * contains the output block
  *
+ * @param {string} name
  * @param {string} commentBody
- * @returns {string}
+ * @returns {boolean}
  */
-const hasOutput = (commentBody) => {
-    return outputRegex.test(commentBody);
+const hasOutput = (name, commentBody) => {
+    return getOutputRegex(name).test(commentBody);
 };
 
 /**
  * Cleans the previous output and attaches the new information
+ * @param {string} name
  * @param {string} previousBody - comment in the pull request
  * @param {string} [outputText] - without content will clean the previous output
  * @returns {string}
  */
-const combineBody = (previousBody, outputText) => {
-    if (hasOutput(previousBody)) {
+const combineBody = (name, previousBody, outputText) => {
+    if (hasOutput(name, previousBody)) {
         return previousBody.replace(
-            outputRegex,
-            outputText ? `\n<!-- output start -->\n${outputText}\n<!-- output end -->` : '',
+            getOutputRegex(name),
+            outputText ? `\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->` : '',
         ).trim();
     } else {
+        console.log('here');
         return outputText
             ? previousBody
                 .trim()
-                .concat(`\n<!-- output start -->\n${outputText}\n<!-- output end -->`)
+                .concat(`\n<!-- output start - ${name} -->\n${outputText}\n<!-- output end - ${name} -->`)
             : previousBody;
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ const combineBody = (data) => {
     } else if (!outputText) {
         return previousBody;
     } else if (data.top) {
-        return output.concat(previousBody);
+        return output.concat(`\n${previousBody}`);
     } else {
         return previousBody.trim().concat(output);
     }


### PR DESCRIPTION
Currently, Output action works only for one output per PR, to fix that we are adding a unique name to each output job.
Also added support for positioning the content on the top part of the pr description
<img width="655" alt="image" src="https://user-images.githubusercontent.com/13871150/187947606-f310f87b-5a30-4f41-8a82-c4575e9fc1e7.png">
